### PR TITLE
eu and es translations

### DIFF
--- a/src/collective/collectionfilter/locales/collective.collectionfilter.pot
+++ b/src/collective/collectionfilter/locales/collective.collectionfilter.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-22 03:05+0000\n"
+"POT-Creation-Date: 2017-04-11 10:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.collectionfilter\n"
 
-#: collective/collectionfilter/portlets/collectionfilter.py:140
+#: collective/collectionfilter/portlets/collectionfilter.py:139
 msgid "Add Collection Filter Portlet"
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionsearch.py:111
+#: collective/collectionfilter/portlets/collectionsearch.py:112
 msgid "Add Collection Search Portlet"
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionfilter.py:86
+#: collective/collectionfilter/portlets/collectionfilter.py:85
 msgid "Collection Filter"
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionsearch.py:56
+#: collective/collectionfilter/portlets/collectionsearch.py:57
 msgid "Collection Search"
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionfilter.py:156
+#: collective/collectionfilter/portlets/collectionfilter.py:155
 msgid "Edit Collection Filter Portlet"
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionsearch.py:126
+#: collective/collectionfilter/portlets/collectionsearch.py:127
 msgid "Edit Collection Search Portlet"
 msgstr ""
 
@@ -46,11 +46,11 @@ msgstr ""
 msgid "Extension profile for Plone."
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionsearch.py:112
+#: collective/collectionfilter/portlets/collectionsearch.py:113
 msgid "This portlet allows fulltext search in collection results."
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionfilter.py:141
+#: collective/collectionfilter/portlets/collectionfilter.py:140
 msgid "This portlet shows grouped criteria of collection results and allows filtering of collection results."
 msgstr ""
 
@@ -66,89 +66,101 @@ msgstr ""
 msgid "collective.collectionfilter portlets uninstall"
 msgstr ""
 
-#. Default: "Use this setting to keeping previously selected criterias active."
-#: collective/collectionfilter/interfaces.py:55
-msgid "help_additive_filter"
+#: collective/collectionfilter/vocabularies.py:108
+msgid "filtertype_and"
+msgstr ""
+
+#: collective/collectionfilter/vocabularies.py:109
+msgid "filtertype_or"
+msgstr ""
+
+#: collective/collectionfilter/vocabularies.py:107
+msgid "filtertype_single"
 msgstr ""
 
 #. Default: "Display filter items as checkboxes or radio buttons, according to the \"Additive Filter\" setting."
-#: collective/collectionfilter/interfaces.py:64
+#: collective/collectionfilter/interfaces.py:67
 msgid "help_as_input"
 msgstr ""
 
 #. Default: "Cache time in seconds. 0 for no caching."
-#: collective/collectionfilter/interfaces.py:45
+#: collective/collectionfilter/interfaces.py:46
 msgid "help_cache_time"
 msgstr ""
 
+#. Default: "Select if single or multiple criterias can be selected and if all (and) or any (or) of the selected criterias must be met.Some index types like ``FieldIndex`` (e.g. Type index) only support the any (or) criteria when set to multiple criterias and ignore, if all (and) is set."
+#: collective/collectionfilter/interfaces.py:56
+msgid "help_filter_type"
+msgstr ""
+
 #. Default: "Select the criteria to group the collection results by."
-#: collective/collectionfilter/interfaces.py:26
+#: collective/collectionfilter/interfaces.py:27
 msgid "help_groupby"
 msgstr ""
 
 #. Default: "Title of the rendered portlet."
-#: collective/collectionfilter/portlets/collectionfilter.py:29
-#: collective/collectionfilter/portlets/collectionsearch.py:29
+#: collective/collectionfilter/portlets/collectionfilter.py:31
+#: collective/collectionfilter/portlets/collectionsearch.py:30
 msgid "help_header"
 msgstr ""
 
-#. Default: "Narrow down the filter options, when a filter of this group is applied. Only options, which are available in the result set will then be displayed. Other filter groups can still narrow down this one, though."
-#: collective/collectionfilter/interfaces.py:73
+#. Default: "Narrow down the filter options when a filter of this group is applied. Only options, which are available in the result set will then be displayed. Other filter groups can still narrow down this one, though."
+#: collective/collectionfilter/interfaces.py:76
 msgid "help_narrow_down"
 msgstr ""
 
 #. Default: "Show the result count for each filter group."
-#: collective/collectionfilter/interfaces.py:36
+#: collective/collectionfilter/interfaces.py:37
 msgid "help_show_count"
 msgstr ""
 
 #. Default: "The collection, which is the source for the filter items and where the filter is applied."
-#: collective/collectionfilter/interfaces.py:13
+#: collective/collectionfilter/interfaces.py:14
 msgid "help_target_collection"
 msgstr ""
 
-#. Default: "Additive Filter"
-#: collective/collectionfilter/interfaces.py:54
-msgid "label_additive_filter"
-msgstr ""
-
 #. Default: "Display as checkboxes or radio buttons"
-#: collective/collectionfilter/interfaces.py:63
+#: collective/collectionfilter/interfaces.py:66
 msgid "label_as_input"
 msgstr ""
 
 #. Default: "Cache Time (s)"
-#: collective/collectionfilter/interfaces.py:44
+#: collective/collectionfilter/interfaces.py:45
 msgid "label_cache_time"
 msgstr ""
 
+#. Default: "Filter Type"
+#: collective/collectionfilter/interfaces.py:55
+msgid "label_filter_type"
+msgstr ""
+
 #. Default: "Group by"
-#: collective/collectionfilter/interfaces.py:25
+#: collective/collectionfilter/interfaces.py:26
 msgid "label_groupby"
 msgstr ""
 
 #. Default: "Portlet header"
-#: collective/collectionfilter/portlets/collectionfilter.py:28
-#: collective/collectionfilter/portlets/collectionsearch.py:28
+#: collective/collectionfilter/portlets/collectionfilter.py:30
+#: collective/collectionfilter/portlets/collectionsearch.py:29
 msgid "label_header"
 msgstr ""
 
 #. Default: "Narrow down filter options"
-#: collective/collectionfilter/interfaces.py:72
+#: collective/collectionfilter/interfaces.py:75
 msgid "label_narrow_down"
 msgstr ""
 
 #. Default: "Show count"
-#: collective/collectionfilter/interfaces.py:35
+#: collective/collectionfilter/interfaces.py:36
 msgid "label_show_count"
 msgstr ""
 
 #. Default: "Target Collection"
-#: collective/collectionfilter/interfaces.py:12
+#: collective/collectionfilter/interfaces.py:13
 msgid "label_target_collection"
 msgstr ""
 
 #. Default: "All"
-#: collective/collectionfilter/filteritems.py:180
+#: collective/collectionfilter/filteritems.py:187
 msgid "subject_all"
 msgstr ""

--- a/src/collective/collectionfilter/locales/de/LC_MESSAGES/collective.collectionfilter.po
+++ b/src/collective/collectionfilter/locales/de/LC_MESSAGES/collective.collectionfilter.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-22 03:05+0000\n"
+"POT-Creation-Date: 2017-04-11 10:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.collectionfilter\n"
 
-#: collective/collectionfilter/portlets/collectionfilter.py:140
+#: collective/collectionfilter/portlets/collectionfilter.py:139
 msgid "Add Collection Filter Portlet"
 msgstr "Portlet zur Filterung von Kollektionen hinzufügen"
 
-#: collective/collectionfilter/portlets/collectionsearch.py:111
+#: collective/collectionfilter/portlets/collectionsearch.py:112
 msgid "Add Collection Search Portlet"
 msgstr "Portlet zur Suche in Kollektionen hinzufügen"
 
-#: collective/collectionfilter/portlets/collectionfilter.py:86
+#: collective/collectionfilter/portlets/collectionfilter.py:85
 msgid "Collection Filter"
 msgstr "Kollektionsfilter"
 
-#: collective/collectionfilter/portlets/collectionsearch.py:56
+#: collective/collectionfilter/portlets/collectionsearch.py:57
 msgid "Collection Search"
 msgstr "Kollektionssuche"
 
-#: collective/collectionfilter/portlets/collectionfilter.py:156
+#: collective/collectionfilter/portlets/collectionfilter.py:155
 msgid "Edit Collection Filter Portlet"
 msgstr "Portlet zur Filterung von Kollektionen bearbeiten"
 
-#: collective/collectionfilter/portlets/collectionsearch.py:126
+#: collective/collectionfilter/portlets/collectionsearch.py:127
 msgid "Edit Collection Search Portlet"
 msgstr "Portlet zur Suche in Kollektionen bearbeiten"
 
@@ -46,11 +46,11 @@ msgstr "Portlet zur Suche in Kollektionen bearbeiten"
 msgid "Extension profile for Plone."
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionsearch.py:112
+#: collective/collectionfilter/portlets/collectionsearch.py:113
 msgid "This portlet allows fulltext search in collection results."
 msgstr "Dieses Portlet erlaubt eine Volltextsuche in Kollektionsergebnissen und schränkt diese weiter ein."
 
-#: collective/collectionfilter/portlets/collectionfilter.py:141
+#: collective/collectionfilter/portlets/collectionfilter.py:140
 msgid "This portlet shows grouped criteria of collection results and allows filtering of collection results."
 msgstr "Dieses Portlet zeigt Gruppierte Kollektionsergebnisse und erlaubt eine weitere Einschränkung der Ergebnisse durch Filter."
 
@@ -66,89 +66,101 @@ msgstr ""
 msgid "collective.collectionfilter portlets uninstall"
 msgstr ""
 
-#. Default: "Use this setting to keeping previously selected criterias active."
-#: collective/collectionfilter/interfaces.py:55
-msgid "help_additive_filter"
-msgstr "Diese Einstellung behält zuvor ausgewählte Filterkriterien aktiv."
+#: collective/collectionfilter/vocabularies.py:108
+msgid "filtertype_and"
+msgstr ""
+
+#: collective/collectionfilter/vocabularies.py:109
+msgid "filtertype_or"
+msgstr ""
+
+#: collective/collectionfilter/vocabularies.py:107
+msgid "filtertype_single"
+msgstr ""
 
 #. Default: "Display filter items as checkboxes or radio buttons, according to the \"Additive Filter\" setting."
-#: collective/collectionfilter/interfaces.py:64
+#: collective/collectionfilter/interfaces.py:67
 msgid "help_as_input"
 msgstr "Die Filterkriterien werden als Checkboxen oder Radio Buttons dargestellt, je nach Einstellung in \"Additiver Filter\"."
 
 #. Default: "Cache time in seconds. 0 for no caching."
-#: collective/collectionfilter/interfaces.py:45
+#: collective/collectionfilter/interfaces.py:46
 msgid "help_cache_time"
 msgstr "Cache Zeit in Sekunden. 0 für kein Caching."
 
+#. Default: "Select if single or multiple criterias can be selected and if all (and) or any (or) of the selected criterias must be met.Some index types like ``FieldIndex`` (e.g. Type index) only support the any (or) criteria when set to multiple criterias and ignore, if all (and) is set."
+#: collective/collectionfilter/interfaces.py:56
+msgid "help_filter_type"
+msgstr ""
+
 #. Default: "Select the criteria to group the collection results by."
-#: collective/collectionfilter/interfaces.py:26
+#: collective/collectionfilter/interfaces.py:27
 msgid "help_groupby"
 msgstr "Kriterium zur Gruppierung der Kollektionsergebnisse auswählen."
 
 #. Default: "Title of the rendered portlet."
-#: collective/collectionfilter/portlets/collectionfilter.py:29
-#: collective/collectionfilter/portlets/collectionsearch.py:29
+#: collective/collectionfilter/portlets/collectionfilter.py:31
+#: collective/collectionfilter/portlets/collectionsearch.py:30
 msgid "help_header"
 msgstr "Titel des Portlets"
 
 #. Default: "Narrow down the filter options when a filter of this group is applied. Only options, which are available in the result set will then be displayed. Other filter groups can still narrow down this one, though."
-#: collective/collectionfilter/interfaces.py:73
+#: collective/collectionfilter/interfaces.py:76
 msgid "help_narrow_down"
 msgstr "Die Filteroptionen werden eingeschränkt, wenn ein Filterkriterium ausgewählt wird. Es werden nur jene Filterkriterien angezeigt, die im aktuellen Ergebnis vorkommen. Andere Filtergruppen können diese Filtergruppe jedoch trotzdem einschränken."
 
 #. Default: "Show the result count for each filter group."
-#: collective/collectionfilter/interfaces.py:36
+#: collective/collectionfilter/interfaces.py:37
 msgid "help_show_count"
 msgstr "Zeige die Anzahl der Ergebnisse für jede Filtergruppe."
 
 #. Default: "The collection, which is the source for the filter items and where the filter is applied."
-#: collective/collectionfilter/interfaces.py:13
+#: collective/collectionfilter/interfaces.py:14
 msgid "help_target_collection"
 msgstr "Bitte wählen Sie die Zielkollektion aus."
 
-#. Default: "Additive Filter"
-#: collective/collectionfilter/interfaces.py:54
-msgid "label_additive_filter"
-msgstr "Additiver Filter"
-
 #. Default: "Display as checkboxes or radio buttons"
-#: collective/collectionfilter/interfaces.py:63
+#: collective/collectionfilter/interfaces.py:66
 msgid "label_as_input"
 msgstr "Filterkriterien als Checkboxen oder Radio Buttons darstellen."
 
 #. Default: "Cache Time (s)"
-#: collective/collectionfilter/interfaces.py:44
+#: collective/collectionfilter/interfaces.py:45
 msgid "label_cache_time"
 msgstr "Cache Zeit (s)"
 
+#. Default: "Filter Type"
+#: collective/collectionfilter/interfaces.py:55
+msgid "label_filter_type"
+msgstr ""
+
 #. Default: "Group by"
-#: collective/collectionfilter/interfaces.py:25
+#: collective/collectionfilter/interfaces.py:26
 msgid "label_groupby"
 msgstr "Gruppierungskriterium"
 
 #. Default: "Portlet header"
-#: collective/collectionfilter/portlets/collectionfilter.py:28
-#: collective/collectionfilter/portlets/collectionsearch.py:28
+#: collective/collectionfilter/portlets/collectionfilter.py:30
+#: collective/collectionfilter/portlets/collectionsearch.py:29
 msgid "label_header"
 msgstr "Portlet Titel"
 
 #. Default: "Narrow down filter options"
-#: collective/collectionfilter/interfaces.py:72
+#: collective/collectionfilter/interfaces.py:75
 msgid "label_narrow_down"
 msgstr "Filterkriterien einschränken"
 
 #. Default: "Show count"
-#: collective/collectionfilter/interfaces.py:35
+#: collective/collectionfilter/interfaces.py:36
 msgid "label_show_count"
 msgstr "Anzahl zeigen"
 
 #. Default: "Target Collection"
-#: collective/collectionfilter/interfaces.py:12
+#: collective/collectionfilter/interfaces.py:13
 msgid "label_target_collection"
 msgstr "Ziel Kollektion"
 
 #. Default: "All"
-#: collective/collectionfilter/filteritems.py:180
+#: collective/collectionfilter/filteritems.py:187
 msgid "subject_all"
 msgstr "Alle"

--- a/src/collective/collectionfilter/locales/de_CH/LC_MESSAGES/collective.collectionfilter.po
+++ b/src/collective/collectionfilter/locales/de_CH/LC_MESSAGES/collective.collectionfilter.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-22 03:05+0000\n"
+"POT-Creation-Date: 2017-04-11 10:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.collectionfilter\n"
 
-#: collective/collectionfilter/portlets/collectionfilter.py:140
+#: collective/collectionfilter/portlets/collectionfilter.py:139
 msgid "Add Collection Filter Portlet"
 msgstr "Portlet zur Filterung von Kollektionen hinzufügen"
 
-#: collective/collectionfilter/portlets/collectionsearch.py:111
+#: collective/collectionfilter/portlets/collectionsearch.py:112
 msgid "Add Collection Search Portlet"
 msgstr "Portlet zur Suche in Kollektionen hinzufügen"
 
-#: collective/collectionfilter/portlets/collectionfilter.py:86
+#: collective/collectionfilter/portlets/collectionfilter.py:85
 msgid "Collection Filter"
 msgstr "Kollektionsfilter"
 
-#: collective/collectionfilter/portlets/collectionsearch.py:56
+#: collective/collectionfilter/portlets/collectionsearch.py:57
 msgid "Collection Search"
 msgstr "Kollektionssuche"
 
-#: collective/collectionfilter/portlets/collectionfilter.py:156
+#: collective/collectionfilter/portlets/collectionfilter.py:155
 msgid "Edit Collection Filter Portlet"
 msgstr "Portlet zur Filterung von Kollektionen bearbeiten"
 
-#: collective/collectionfilter/portlets/collectionsearch.py:126
+#: collective/collectionfilter/portlets/collectionsearch.py:127
 msgid "Edit Collection Search Portlet"
 msgstr "Portlet zur Suche in Kollektionen bearbeiten"
 
@@ -46,11 +46,11 @@ msgstr "Portlet zur Suche in Kollektionen bearbeiten"
 msgid "Extension profile for Plone."
 msgstr ""
 
-#: collective/collectionfilter/portlets/collectionsearch.py:112
+#: collective/collectionfilter/portlets/collectionsearch.py:113
 msgid "This portlet allows fulltext search in collection results."
 msgstr "Dieses Portlet erlaubt eine Volltextsuche in Kollektionsergebnissen und schränkt diese weiter ein."
 
-#: collective/collectionfilter/portlets/collectionfilter.py:141
+#: collective/collectionfilter/portlets/collectionfilter.py:140
 msgid "This portlet shows grouped criteria of collection results and allows filtering of collection results."
 msgstr "Dieses Portlet zeigt Gruppierte Kollektionsergebnisse und erlaubt eine weitere Einschränkung der Ergebnisse durch Filter."
 
@@ -66,89 +66,101 @@ msgstr ""
 msgid "collective.collectionfilter portlets uninstall"
 msgstr ""
 
-#. Default: "Use this setting to keeping previously selected criterias active."
-#: collective/collectionfilter/interfaces.py:55
-msgid "help_additive_filter"
-msgstr "Diese Einstellung behält zuvor ausgewählte Filterkriterien aktiv."
+#: collective/collectionfilter/vocabularies.py:108
+msgid "filtertype_and"
+msgstr ""
+
+#: collective/collectionfilter/vocabularies.py:109
+msgid "filtertype_or"
+msgstr ""
+
+#: collective/collectionfilter/vocabularies.py:107
+msgid "filtertype_single"
+msgstr ""
 
 #. Default: "Display filter items as checkboxes or radio buttons, according to the \"Additive Filter\" setting."
-#: collective/collectionfilter/interfaces.py:64
+#: collective/collectionfilter/interfaces.py:67
 msgid "help_as_input"
 msgstr "Die Filterkriterien werden als Checkboxen oder Radio Buttons dargestellt, je nach Einstellung in \"Additiver Filter\"."
 
 #. Default: "Cache time in seconds. 0 for no caching."
-#: collective/collectionfilter/interfaces.py:45
+#: collective/collectionfilter/interfaces.py:46
 msgid "help_cache_time"
 msgstr "Cache Zeit in Sekunden. 0 für kein Caching."
 
+#. Default: "Select if single or multiple criterias can be selected and if all (and) or any (or) of the selected criterias must be met.Some index types like ``FieldIndex`` (e.g. Type index) only support the any (or) criteria when set to multiple criterias and ignore, if all (and) is set."
+#: collective/collectionfilter/interfaces.py:56
+msgid "help_filter_type"
+msgstr ""
+
 #. Default: "Select the criteria to group the collection results by."
-#: collective/collectionfilter/interfaces.py:26
+#: collective/collectionfilter/interfaces.py:27
 msgid "help_groupby"
 msgstr "Kriterium zur Gruppierung der Kollektionsergebnisse auswählen."
 
 #. Default: "Title of the rendered portlet."
-#: collective/collectionfilter/portlets/collectionfilter.py:29
-#: collective/collectionfilter/portlets/collectionsearch.py:29
+#: collective/collectionfilter/portlets/collectionfilter.py:31
+#: collective/collectionfilter/portlets/collectionsearch.py:30
 msgid "help_header"
 msgstr "Titel des Portlets"
 
 #. Default: "Narrow down the filter options when a filter of this group is applied. Only options, which are available in the result set will then be displayed. Other filter groups can still narrow down this one, though."
-#: collective/collectionfilter/interfaces.py:73
+#: collective/collectionfilter/interfaces.py:76
 msgid "help_narrow_down"
 msgstr "Die Filteroptionen werden eingeschränkt, wenn ein Filterkriterium ausgewählt wird. Es werden nur jene Filterkriterien angezeigt, die im aktuellen Ergebnis vorkommen. Andere Filtergruppen können diese Filtergruppe jedoch trotzdem einschränken."
 
 #. Default: "Show the result count for each filter group."
-#: collective/collectionfilter/interfaces.py:36
+#: collective/collectionfilter/interfaces.py:37
 msgid "help_show_count"
 msgstr "Zeige die Anzahl der Ergebnisse für jede Filtergruppe."
 
 #. Default: "The collection, which is the source for the filter items and where the filter is applied."
-#: collective/collectionfilter/interfaces.py:13
+#: collective/collectionfilter/interfaces.py:14
 msgid "help_target_collection"
 msgstr "Bitte wählen Sie die Zielkollektion aus."
 
-#. Default: "Additive Filter"
-#: collective/collectionfilter/interfaces.py:54
-msgid "label_additive_filter"
-msgstr "Additiver Filter"
-
 #. Default: "Display as checkboxes or radio buttons"
-#: collective/collectionfilter/interfaces.py:63
+#: collective/collectionfilter/interfaces.py:66
 msgid "label_as_input"
 msgstr "Filterkriterien als Checkboxen oder Radio Buttons darstellen."
 
 #. Default: "Cache Time (s)"
-#: collective/collectionfilter/interfaces.py:44
+#: collective/collectionfilter/interfaces.py:45
 msgid "label_cache_time"
 msgstr "Cache Zeit (s)"
 
+#. Default: "Filter Type"
+#: collective/collectionfilter/interfaces.py:55
+msgid "label_filter_type"
+msgstr ""
+
 #. Default: "Group by"
-#: collective/collectionfilter/interfaces.py:25
+#: collective/collectionfilter/interfaces.py:26
 msgid "label_groupby"
 msgstr "Gruppierungskriterium"
 
 #. Default: "Portlet header"
-#: collective/collectionfilter/portlets/collectionfilter.py:28
-#: collective/collectionfilter/portlets/collectionsearch.py:28
+#: collective/collectionfilter/portlets/collectionfilter.py:30
+#: collective/collectionfilter/portlets/collectionsearch.py:29
 msgid "label_header"
 msgstr "Portlet Titel"
 
 #. Default: "Narrow down filter options"
-#: collective/collectionfilter/interfaces.py:72
+#: collective/collectionfilter/interfaces.py:75
 msgid "label_narrow_down"
 msgstr "Filterkriterien einschränken"
 
 #. Default: "Show count"
-#: collective/collectionfilter/interfaces.py:35
+#: collective/collectionfilter/interfaces.py:36
 msgid "label_show_count"
 msgstr "Anzahl zeigen"
 
 #. Default: "Target Collection"
-#: collective/collectionfilter/interfaces.py:12
+#: collective/collectionfilter/interfaces.py:13
 msgid "label_target_collection"
 msgstr "Ziel Kollektion"
 
 #. Default: "All"
-#: collective/collectionfilter/filteritems.py:180
+#: collective/collectionfilter/filteritems.py:187
 msgid "subject_all"
 msgstr "Alle"

--- a/src/collective/collectionfilter/locales/es/LC_MESSAGES/collective.collectionfilter.po
+++ b/src/collective/collectionfilter/locales/es/LC_MESSAGES/collective.collectionfilter.po
@@ -1,0 +1,165 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2017-04-11 09:28+0000\n"
+"PO-Revision-Date: 2017-04-11 11:39+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+"Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
+"Language-Team: \n"
+"Language: es\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#: collective/collectionfilter/portlets/collectionfilter.py:139
+msgid "Add Collection Filter Portlet"
+msgstr "Añadir portlet de filtro de colección"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:112
+msgid "Add Collection Search Portlet"
+msgstr "Añadir portlet de búsqueda en colección"
+
+#: collective/collectionfilter/portlets/collectionfilter.py:85
+msgid "Collection Filter"
+msgstr "Filtro de colección"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:57
+msgid "Collection Search"
+msgstr "Búsqueda en colección"
+
+#: collective/collectionfilter/portlets/collectionfilter.py:155
+msgid "Edit Collection Filter Portlet"
+msgstr "Editar portlet de filtro de colección"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:127
+msgid "Edit Collection Search Portlet"
+msgstr "Editar portlet de búsqueda en colección"
+
+#: collective/collectionfilter/configure.zcml:47
+#: collective/collectionfilter/portlets/configure.zcml:36
+msgid "Extension profile for Plone."
+msgstr "Perfil de extensión para Plone"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:113
+msgid "This portlet allows fulltext search in collection results."
+msgstr "Este portlet permite búsquedas de texto completo entre los resultados de la colección"
+
+#: collective/collectionfilter/portlets/collectionfilter.py:140
+msgid "This portlet shows grouped criteria of collection results and allows filtering of collection results."
+msgstr "Este portlet muestra criterios para poder filtrar los resultados de una colección."
+
+#: collective/collectionfilter/configure.zcml:47
+msgid "collective.collectionfilter base"
+msgstr "collective.collectionfilter base"
+
+#: collective/collectionfilter/portlets/configure.zcml:36
+msgid "collective.collectionfilter portlets"
+msgstr "collective.collectionfilter portlets"
+
+#: collective/collectionfilter/portlets/configure.zcml:44
+msgid "collective.collectionfilter portlets uninstall"
+msgstr "collective.collectionfilter portlets uninstall"
+
+#: collective/collectionfilter/vocabularies.py:108
+msgid "filtertype_and"
+msgstr "filtro \"Y\""
+
+#: collective/collectionfilter/vocabularies.py:109
+msgid "filtertype_or"
+msgstr "filtro \"O\""
+
+#: collective/collectionfilter/vocabularies.py:107
+msgid "filtertype_single"
+msgstr "filtro exclusivo"
+
+#. Default: "Display filter items as checkboxes or radio buttons, according to the \"Additive Filter\" setting."
+#: collective/collectionfilter/interfaces.py:67
+msgid "help_as_input"
+msgstr "Mostrar los elementos del filtro como opciones de selección múltiple o única, de acuerdo con la configuración de \"Filtro aditivo\""
+
+#. Default: "Cache time in seconds. 0 for no caching."
+#: collective/collectionfilter/interfaces.py:46
+msgid "help_cache_time"
+msgstr "Tiempo de cache en segundos. 0 para no cachear."
+
+#. Default: "Select if single or multiple criterias can be selected and if all (and) or any (or) of the selected criterias must be met.Some index types like ``FieldIndex`` (e.g. Type index) only support the any (or) criteria when set to multiple criterias and ignore, if all (and) is set."
+#: collective/collectionfilter/interfaces.py:56
+msgid "help_filter_type"
+msgstr "Seleccione si se pueden seleccionar filtros de forma única o múltiple y si se tienen que cumplir todos (Y) o algunos (O) de los criterios selecionados. Algunos índices, como los ``FieldIndex`` (p.ej: el índice tipos de elemento) solo pueden buscar por el criterio 'O' cuando tienen varios valores y los ignora si está seleccionado el 'Y'."
+
+#. Default: "Select the criteria to group the collection results by."
+#: collective/collectionfilter/interfaces.py:27
+msgid "help_groupby"
+msgstr "Seleccione el criterio por el que se agruparan los resultados de la colección."
+
+#. Default: "Title of the rendered portlet."
+#: collective/collectionfilter/portlets/collectionfilter.py:31
+#: collective/collectionfilter/portlets/collectionsearch.py:30
+msgid "help_header"
+msgstr "Título del portlet"
+
+#. Default: "Narrow down the filter options when a filter of this group is applied. Only options, which are available in the result set will then be displayed. Other filter groups can still narrow down this one, though."
+#: collective/collectionfilter/interfaces.py:76
+msgid "help_narrow_down"
+msgstr "Restringir las opciones de los filtros cuando un filtro de este grupo se aplique. Solo las opciones que se encontrarán entre los resultados se mostrarńa. Otros filtros podrán restringir aún más los valores de éste."
+
+#. Default: "Show the result count for each filter group."
+#: collective/collectionfilter/interfaces.py:37
+msgid "help_show_count"
+msgstr "Mostrar la cantidad de elementos para cada filtro"
+
+#. Default: "The collection, which is the source for the filter items and where the filter is applied."
+#: collective/collectionfilter/interfaces.py:14
+msgid "help_target_collection"
+msgstr "La colección de la que se realizará el filtro"
+
+#. Default: "Display as checkboxes or radio buttons"
+#: collective/collectionfilter/interfaces.py:66
+msgid "label_as_input"
+msgstr "Mostrar las opciones como opciones de selección múltiple o simple."
+
+#. Default: "Cache Time (s)"
+#: collective/collectionfilter/interfaces.py:45
+msgid "label_cache_time"
+msgstr "Tiempo de caché"
+
+#. Default: "Filter Type"
+#: collective/collectionfilter/interfaces.py:55
+msgid "label_filter_type"
+msgstr "Tipo de filtro"
+
+#. Default: "Group by"
+#: collective/collectionfilter/interfaces.py:26
+msgid "label_groupby"
+msgstr "Agrupar por"
+
+#. Default: "Portlet header"
+#: collective/collectionfilter/portlets/collectionfilter.py:30
+#: collective/collectionfilter/portlets/collectionsearch.py:29
+msgid "label_header"
+msgstr "Título del portlet"
+
+#. Default: "Narrow down filter options"
+#: collective/collectionfilter/interfaces.py:75
+msgid "label_narrow_down"
+msgstr "Restringir filtros"
+
+#. Default: "Show count"
+#: collective/collectionfilter/interfaces.py:36
+msgid "label_show_count"
+msgstr "Mostrar cantidades"
+
+#. Default: "Target Collection"
+#: collective/collectionfilter/interfaces.py:13
+msgid "label_target_collection"
+msgstr "Colección"
+
+#. Default: "All"
+#: collective/collectionfilter/filteritems.py:187
+msgid "subject_all"
+msgstr "Todos"

--- a/src/collective/collectionfilter/locales/eu/LC_MESSAGES/collective.collectionfilter.po
+++ b/src/collective/collectionfilter/locales/eu/LC_MESSAGES/collective.collectionfilter.po
@@ -1,0 +1,165 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2017-04-11 09:28+0000\n"
+"PO-Revision-Date: 2017-04-11 12:01+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+"Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
+"Language-Team: \n"
+"Language: eu\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#: collective/collectionfilter/portlets/collectionfilter.py:139
+msgid "Add Collection Filter Portlet"
+msgstr "Bildumaren filtro-portleta gehitu"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:112
+msgid "Add Collection Search Portlet"
+msgstr "Bildumaren bilaketa-portleta gehitu"
+
+#: collective/collectionfilter/portlets/collectionfilter.py:85
+msgid "Collection Filter"
+msgstr "Bildumaren filtroa"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:57
+msgid "Collection Search"
+msgstr "Bildumaren bilaketa"
+
+#: collective/collectionfilter/portlets/collectionfilter.py:155
+msgid "Edit Collection Filter Portlet"
+msgstr "Bildumaren filtro-portleta editatu"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:127
+msgid "Edit Collection Search Portlet"
+msgstr "Bildumaren bilaketa-portleta editatu"
+
+#: collective/collectionfilter/configure.zcml:47
+#: collective/collectionfilter/portlets/configure.zcml:36
+msgid "Extension profile for Plone."
+msgstr "Ploneren profila"
+
+#: collective/collectionfilter/portlets/collectionsearch.py:113
+msgid "This portlet allows fulltext search in collection results."
+msgstr "Portlet honek bilduma baten emaitzetan testu-bilaketak egiten ditu."
+
+#: collective/collectionfilter/portlets/collectionfilter.py:140
+msgid "This portlet shows grouped criteria of collection results and allows filtering of collection results."
+msgstr "Portlet honek bilduma baten emaitzetan konfiguratutako eremuen araberako filtroak egiten ditu."
+
+#: collective/collectionfilter/configure.zcml:47
+msgid "collective.collectionfilter base"
+msgstr "collective.collectionfilter base"
+
+#: collective/collectionfilter/portlets/configure.zcml:36
+msgid "collective.collectionfilter portlets"
+msgstr "collective.collectionfilter base"
+
+#: collective/collectionfilter/portlets/configure.zcml:44
+msgid "collective.collectionfilter portlets uninstall"
+msgstr "collective.collectionfilter base"
+
+#: collective/collectionfilter/vocabularies.py:108
+msgid "filtertype_and"
+msgstr "eta"
+
+#: collective/collectionfilter/vocabularies.py:109
+msgid "filtertype_or"
+msgstr "edo"
+
+#: collective/collectionfilter/vocabularies.py:107
+msgid "filtertype_single"
+msgstr "bakarra"
+
+#. Default: "Display filter items as checkboxes or radio buttons, according to the \"Additive Filter\" setting."
+#: collective/collectionfilter/interfaces.py:67
+msgid "help_as_input"
+msgstr "Filtroaren elementuak aukeraketa edo irrati botoi gisa erakutsi \"Filtro gehigarriak\" aukeraren arabera"
+
+#. Default: "Cache time in seconds. 0 for no caching."
+#: collective/collectionfilter/interfaces.py:46
+msgid "help_cache_time"
+msgstr "Katxe denbora segundutan. 0 idazten baduzu, ez da katxerik egongo."
+
+#. Default: "Select if single or multiple criterias can be selected and if all (and) or any (or) of the selected criterias must be met.Some index types like ``FieldIndex`` (e.g. Type index) only support the any (or) criteria when set to multiple criterias and ignore, if all (and) is set."
+#: collective/collectionfilter/interfaces.py:56
+msgid "help_filter_type"
+msgstr "Aukeratu filtro guztiak (eta) edo bat baino gehiago (edo) bete behar diren egindo den bilaketan. Filtro batzuk ``FieldIndex`` motakoek, `edo` filtroa aplikatzen dute elementu bat baino gehiago eskatuz gero eta ez dute kontuan hartzen `eta` filtroa erabiliz gero."
+
+#. Default: "Select the criteria to group the collection results by."
+#: collective/collectionfilter/interfaces.py:27
+msgid "help_groupby"
+msgstr "Aukeratu zeren araberako filtroa egingo den."
+
+#. Default: "Title of the rendered portlet."
+#: collective/collectionfilter/portlets/collectionfilter.py:31
+#: collective/collectionfilter/portlets/collectionsearch.py:30
+msgid "help_header"
+msgstr "Portletaren goiburua"
+
+#. Default: "Narrow down the filter options when a filter of this group is applied. Only options, which are available in the result set will then be displayed. Other filter groups can still narrow down this one, though."
+#: collective/collectionfilter/interfaces.py:76
+msgid "help_narrow_down"
+msgstr "Filtroaren aukeretako bat aukeratzen duzunean, aukerak murriztu. Emaitza gisa ikusten diren elementuek dituzten balioak bakarrik egongo dira zerrendan. Beste filtro batzuek ere murriztu ditzakete hemengo balioak."
+
+#. Default: "Show the result count for each filter group."
+#: collective/collectionfilter/interfaces.py:37
+msgid "help_show_count"
+msgstr "Erakutsi zenbat elementu dagoen aukera bakoitzeko."
+
+#. Default: "The collection, which is the source for the filter items and where the filter is applied."
+#: collective/collectionfilter/interfaces.py:14
+msgid "help_target_collection"
+msgstr "Elementuen filtroa egiteko erabiliko den bilduma"
+
+#. Default: "Display as checkboxes or radio buttons"
+#: collective/collectionfilter/interfaces.py:66
+msgid "label_as_input"
+msgstr "Aukeraketa- edo irrati-botoi kutxak erakutsi"
+
+#. Default: "Cache Time (s)"
+#: collective/collectionfilter/interfaces.py:45
+msgid "label_cache_time"
+msgstr "Katxe denbora"
+
+#. Default: "Filter Type"
+#: collective/collectionfilter/interfaces.py:55
+msgid "label_filter_type"
+msgstr "Filtro-mota"
+
+#. Default: "Group by"
+#: collective/collectionfilter/interfaces.py:26
+msgid "label_groupby"
+msgstr "Zeren arabera filtratu"
+
+#. Default: "Portlet header"
+#: collective/collectionfilter/portlets/collectionfilter.py:30
+#: collective/collectionfilter/portlets/collectionsearch.py:29
+msgid "label_header"
+msgstr "Portletaren izenburua"
+
+#. Default: "Narrow down filter options"
+#: collective/collectionfilter/interfaces.py:75
+msgid "label_narrow_down"
+msgstr "Filtroak murriztu"
+
+#. Default: "Show count"
+#: collective/collectionfilter/interfaces.py:36
+msgid "label_show_count"
+msgstr "Kopuruak erakutsi"
+
+#. Default: "Target Collection"
+#: collective/collectionfilter/interfaces.py:13
+msgid "label_target_collection"
+msgstr "Bilduma"
+
+#. Default: "All"
+#: collective/collectionfilter/filteritems.py:187
+msgid "subject_all"
+msgstr "Guztiak"


### PR DESCRIPTION
I run the build_i18n script and some german translations regarding the `additive filter` were deleted, anyway this setting is not used anymore, so it should be safe.