### PR TITLE
fix filteritems when IGroupByCriteria has missing sort_key_function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,9 @@ Bug fixes:
 
 - Sort the filter value list for filter title instead filter value.
 
+- when providing a custom `IGroupByCriteria` adapter, fallback to title sorted values if no sort_key_function is given.
+  [petschki]
+
 
 1.0.1 (2018-02-09)
 ------------------

--- a/src/collective/collectionfilter/filteritems.py
+++ b/src/collective/collectionfilter/filteritems.py
@@ -123,7 +123,9 @@ def get_filter_items(
     value_blacklist = groupby_criteria[group_by].get('value_blacklist', None)
     # Allow value_blacklist to be callables for runtime-evaluation
     value_blacklist = value_blacklist() if callable(value_blacklist) else value_blacklist  # noqa
-    sort_key_function = groupby_criteria[group_by].get('sort_key_function', None)
+    # fallback to title sorted values
+    sort_key_function = groupby_criteria[group_by].get(
+        'sort_key_function', lambda it: it['title'].lower())
 
     grouped_results = {}
     for brain in catalog_results:
@@ -210,11 +212,10 @@ def get_filter_items(
         'selected': idx not in request_params
     }]
 
+    grouped_results = grouped_results.values()
+
     if callable(sort_key_function):
-        grouped_results = sorted(
-            grouped_results.values(),
-            key=sort_key_function
-        )
+        grouped_results = sorted(grouped_results, key=sort_key_function)
 
     ret += grouped_results
 


### PR DESCRIPTION
The adapter example here https://github.com/collective/collective.collectionfilter/blob/master/README.rst has no sort_key_function, so you get a template error because the returned filteritems are `grouped_results.keys()` instead of `grouped_results.values()` ... this fixes it.