### PR TITLE
fix collectionsearch portlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ Bug fixes:
 
 - Sort the filter value list for filter title instead filter value.
 
+- fix collectionsearch portlet
+  [petschki]
 
 1.0.1 (2018-02-09)
 ------------------

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -4,6 +4,7 @@ from .utils import base_query
 from .utils import safe_decode
 from .utils import safe_encode
 from .vocabularies import TEXT_IDX
+from Acquisition import aq_inner
 from plone.app.uuid.utils import uuidToCatalogBrain
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFPlone.utils import get_top_request
@@ -59,7 +60,7 @@ class BaseView(object):
             self._collection = uuidToCatalogBrain(
                 self.settings.target_collection
             )
-        return self._collection
+        return aq_inner(self._collection)
 
 
 class BaseFilterView(BaseView):

--- a/src/collective/collectionfilter/portlets/collectionsearch.pt
+++ b/src/collective/collectionfilter/portlets/collectionsearch.pt
@@ -8,7 +8,7 @@
        i18n:domain="plone">
 
   <tal:if condition="view/settings/target_collection">
-  <header tal:condition="view/title" tal:content="view/title">Title</header>
+  <header class="portletHeader" tal:condition="view/title" tal:content="view/title">Title</header>
   <div class="searchContent">
     <form method="get" name="searchForm" role="form" action="${view/action_url}">
         <input type="hidden" name="collectionfilter" value="1"/>


### PR DESCRIPTION
aq_inner around the collection catalog brain fixes `getURL` to acquire the catalog not the portlet `Renderer` class. 