### PR TITLE
Make compatible with 5.0.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,10 @@ Changelog
 
 Breaking changes:
 
+- Depend on Products.CMFPlone >= 5.0
+
 - Remove the ``cache_time`` setting and replace it with ``cache_enabled``.
-- Depend on Products.CMFPlone >= 5.1 for using ``get_top_request``.
+
 - collectionsearch.pt: changed view attribute ``header_title`` to ``title``.
 
 - Depend on plone.app.contenttypes.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,6 @@ Changelog
 
 Breaking changes:
 
-- Depend on Products.CMFPlone >= 5.0
-
 - Remove the ``cache_time`` setting and replace it with ``cache_enabled``.
 
 - collectionsearch.pt: changed view attribute ``header_title`` to ``title``.
@@ -43,6 +41,9 @@ New:
 - Add ``content_selector`` configuration parameter to choose a DOM node from the source to inject into the target.
 
 - Ensure early exit on the content filter traverse handler if it is not needed to run.
+
+- Make backwards compatible with Plone 5.0
+  [nngu6036, instification]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,10 @@ Done.
 
 Your adapter is called by ``collective.collectionfilter.vocabularies.GroupByCriteria.groupby``.
 
+Compatibility
+-------------
+
+This package is compatible with Plone 5 and above. Note that in 5.0 some functionality is reduced such as AJAX loading of search results.
 
 Author
 ------

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ collective.collectionfilter
 
 Faceted navigation filter for collection results.
 
-This Plone addon allows you to filter collections results for additional catalog metadata.
+This Plone 5 addon allows you to filter collections results for additional catalog metadata.
 For example, you can add a subject filter, but also a filter for authors or portal types.
 This can also be used to build tag clouds.
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     ),
     classifiers=[
         "Framework :: Plone",
+        "Framework :: Plone :: 5.0",
         "Framework :: Plone :: 5.1",
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",
@@ -30,7 +31,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'Products.CMFPlone',  # need get_top_request
+        'Products.CMFPlone >= 5.0',
         'plone.app.contenttypes',
     ],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'Products.CMFPlone >= 5.1',  # need get_top_request
+        'Products.CMFPlone',  # need get_top_request
         'plone.app.contenttypes',
     ],
     entry_points="""

--- a/src/collective/collectionfilter/__init__.py
+++ b/src/collective/collectionfilter/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
 from zope.i18nmessageid import MessageFactory
+from plone.api import env
+
 
 _ = MessageFactory('collective.collectionfilter')
+
+PLONE_VERSION = env.plone_version()

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -59,7 +59,7 @@ class BaseView(object):
             self._collection = uuidToCatalogBrain(
                 self.settings.target_collection
             )
-        return self._collection
+        return self._collection.aq_inner
 
 
 class BaseFilterView(BaseView):

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -7,10 +7,14 @@ from .vocabularies import TEXT_IDX
 from Acquisition import aq_inner
 from plone.app.uuid.utils import uuidToCatalogBrain
 from plone.i18n.normalizer.interfaces import IIDNormalizer
-from .utils import get_top_request
 from Products.CMFPlone.utils import safe_unicode
 from urllib import urlencode
 from zope.component import queryUtility
+
+try:
+    from Products.CMFPlone.utils import get_top_request
+except ImportError:
+    from collective.collectionfilter.utils import get_top_request
 
 
 class BaseView(object):

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -6,7 +6,7 @@ from .utils import safe_encode
 from .vocabularies import TEXT_IDX
 from plone.app.uuid.utils import uuidToCatalogBrain
 from plone.i18n.normalizer.interfaces import IIDNormalizer
-from Products.CMFPlone.utils import get_top_request
+from .utils import get_top_request
 from Products.CMFPlone.utils import safe_unicode
 from urllib import urlencode
 from zope.component import queryUtility

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -5,6 +5,7 @@ from .utils import safe_decode
 from .utils import safe_encode
 from .vocabularies import TEXT_IDX
 from Acquisition import aq_inner
+from collective.collectionfilter import PLONE_VERSION
 from plone.app.uuid.utils import uuidToCatalogBrain
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFPlone.utils import safe_unicode
@@ -65,6 +66,12 @@ class BaseView(object):
                 self.settings.target_collection
             )
         return aq_inner(self._collection)
+
+    @property
+    def patCollectionFilter(self):
+        if PLONE_VERSION >= '5.1':
+            return 'pat-collectionfilter'
+        return ''
 
 
 class BaseFilterView(BaseView):

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -59,7 +59,7 @@ class BaseView(object):
             self._collection = uuidToCatalogBrain(
                 self.settings.target_collection
             )
-        return self._collection.aq_inner
+        return self._collection
 
 
 class BaseFilterView(BaseView):

--- a/src/collective/collectionfilter/interfaces.py
+++ b/src/collective/collectionfilter/interfaces.py
@@ -33,9 +33,8 @@ class ICollectionFilterBaseSchema(Interface):
         'target_collection',
         RelatedItemsFieldWidget,
         pattern_options={
-            'basePath': utils.target_collection_base_path,
             'recentlyUsed': True,
-            # 'selectableTypes': ['Collection'],
+             'selectableTypes': ['Collection'],
         }
     )
 

--- a/src/collective/collectionfilter/interfaces.py
+++ b/src/collective/collectionfilter/interfaces.py
@@ -1,11 +1,23 @@
 # -*- coding: utf-8 -*-
 from . import _
 from . import utils
+from collective.collectionfilter import PLONE_VERSION
 from plone.app.vocabularies.catalog import CatalogSource
 from plone.app.z3cform.widget import RelatedItemsFieldWidget
 from plone.autoform.directives import widget
 from zope import schema
 from zope.interface import Interface
+
+
+def pattern_options():
+    options = {
+        'basePath': utils.target_collection_base_path,
+        'recentlyUsed': True,
+        # 'selectableTypes': ['Collection'],
+    }
+    if PLONE_VERSION < '5.1':
+        del options['basePath']
+    return options
 
 
 class ICollectionFilterBaseSchema(Interface):
@@ -32,10 +44,7 @@ class ICollectionFilterBaseSchema(Interface):
     widget(
         'target_collection',
         RelatedItemsFieldWidget,
-        pattern_options={
-            'recentlyUsed': True,
-             'selectableTypes': ['Collection'],
-        }
+        pattern_options=pattern_options()
     )
 
     view_name = schema.TextLine(

--- a/src/collective/collectionfilter/portlets/collectionfilter.pt
+++ b/src/collective/collectionfilter/portlets/collectionfilter.pt
@@ -1,4 +1,4 @@
-<aside class="portlet ${view/filterClassName} collectionFilter pat-collectionfilter"
+<aside class="portlet ${view/filterClassName} collectionFilter ${view/settings/patCollectionFilter}"
        tal:define="input_type view/input_type"
        data-pat-collectionfilter='{
           "collectionUUID": "${view/settings/target_collection}",

--- a/src/collective/collectionfilter/portlets/collectionfilter.py
+++ b/src/collective/collectionfilter/portlets/collectionfilter.py
@@ -5,7 +5,7 @@ from ..interfaces import ICollectionFilterSchema
 from ..vocabularies import DEFAULT_FILTER_TYPE
 from plone.app.portlets.portlets import base
 from plone.portlets.interfaces import IPortletDataProvider
-from Products.CMFPlone.utils import get_top_request
+from ..utils import get_top_request
 from Products.CMFPlone.utils import getFSVersionTuple
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implementer

--- a/src/collective/collectionfilter/portlets/collectionfilter.py
+++ b/src/collective/collectionfilter/portlets/collectionfilter.py
@@ -5,26 +5,19 @@ from ..interfaces import ICollectionFilterSchema
 from ..vocabularies import DEFAULT_FILTER_TYPE
 from plone.app.portlets.portlets import base
 from plone.portlets.interfaces import IPortletDataProvider
-from ..utils import get_top_request
-from Products.CMFPlone.utils import getFSVersionTuple
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implementer
 
-
-PLONE5 = getFSVersionTuple()[0] >= 5
-
-if PLONE5:
-    base_AddForm = base.AddForm
-    base_EditForm = base.EditForm
-else:
-    from plone.app.portlets.browser.z3cformhelper import AddForm as base_AddForm  # noqa
-    from plone.app.portlets.browser.z3cformhelper import EditForm as base_EditForm  # noqa
-    from z3c.form import field
+try:
+    from Products.CMFPlone.utils import get_top_request
+except ImportError:
+    from collective.collectionfilter.utils import get_top_request
 
 
 class ICollectionFilterPortlet(ICollectionFilterSchema, IPortletDataProvider):
     """Portlet interface based on ICollectionFilterSchema
     """
+
 
 @implementer(ICollectionFilterPortlet)
 class Assignment(base.Assignment):
@@ -102,12 +95,9 @@ class Renderer(base.Renderer, BaseFilterView):
         return reload_url
 
 
-class AddForm(base_AddForm):
-    if PLONE5:
-        schema = ICollectionFilterPortlet
-    else:
-        fields = field.Fields(ICollectionFilterPortlet)
+class AddForm(base.AddForm):
 
+    schema = ICollectionFilterPortlet
     label = _(u"Add Collection Filter Portlet")
     description = _(
         u"This portlet shows grouped criteria of collection results and "
@@ -118,12 +108,9 @@ class AddForm(base_AddForm):
         return Assignment(**data)
 
 
-class EditForm(base_EditForm):
-    if PLONE5:
-        schema = ICollectionFilterPortlet
-    else:
-        fields = field.Fields(ICollectionFilterPortlet)
+class EditForm(base.EditForm):
 
+    schema = ICollectionFilterPortlet
     label = _(u"Edit Collection Filter Portlet")
     description = _(
         u"This portlet shows grouped criteria of collection results and "

--- a/src/collective/collectionfilter/portlets/collectionsearch.pt
+++ b/src/collective/collectionfilter/portlets/collectionsearch.pt
@@ -1,4 +1,4 @@
-<aside class="portlet ${view/filterClassName} collectionSearch pat-collectionfilter"
+<aside class="portlet ${view/filterClassName} collectionSearch ${view/settings/patCollectionFilter}"
        data-pat-collectionfilter='{
            "collectionUUID": "${view/settings/target_collection}",
            "reloadURL": "${view/reload_url}",

--- a/src/collective/collectionfilter/portlets/collectionsearch.py
+++ b/src/collective/collectionfilter/portlets/collectionsearch.py
@@ -4,22 +4,13 @@ from ..baseviews import BaseSearchView
 from ..interfaces import ICollectionSearchSchema
 from plone.app.portlets.portlets import base
 from plone.portlets.interfaces import IPortletDataProvider
-from ..utils import get_top_request
-from Products.CMFPlone.utils import getFSVersionTuple
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from zope.component import queryUtility
 from zope.interface import implementer
 
-
-PLONE5 = getFSVersionTuple()[0] >= 5
-
-if PLONE5:
-    base_AddForm = base.AddForm
-    base_EditForm = base.EditForm
-else:
-    from plone.app.portlets.browser.z3cformhelper import AddForm as base_AddForm  # noqa
-    from plone.app.portlets.browser.z3cformhelper import EditForm as base_EditForm  # noqa
-    from z3c.form import field
+try:
+    from Products.CMFPlone.utils import get_top_request
+except ImportError:
+    from collective.collectionfilter.utils import get_top_request
 
 
 class ICollectionSearchPortlet(ICollectionSearchSchema, IPortletDataProvider):
@@ -76,12 +67,9 @@ class Renderer(base.Renderer, BaseSearchView):
         return reload_url
 
 
-class AddForm(base_AddForm):
-    if PLONE5:
-        schema = ICollectionSearchPortlet
-    else:
-        fields = field.Fields(ICollectionSearchPortlet)
+class AddForm(base.AddForm):
 
+    schema = ICollectionSearchPortlet
     label = _(u"Add Collection Search Portlet")
     description = _(
         u"This portlet allows fulltext search in collection results."
@@ -91,12 +79,9 @@ class AddForm(base_AddForm):
         return Assignment(**data)
 
 
-class EditForm(base_EditForm):
-    if PLONE5:
-        schema = ICollectionSearchPortlet
-    else:
-        fields = field.Fields(ICollectionSearchPortlet)
+class EditForm(base.EditForm):
 
+    schema = ICollectionSearchPortlet
     label = _(u"Edit Collection Search Portlet")
     description = _(
         u"This portlet allows fulltext search in collection results."

--- a/src/collective/collectionfilter/portlets/collectionsearch.py
+++ b/src/collective/collectionfilter/portlets/collectionsearch.py
@@ -4,7 +4,7 @@ from ..baseviews import BaseSearchView
 from ..interfaces import ICollectionSearchSchema
 from plone.app.portlets.portlets import base
 from plone.portlets.interfaces import IPortletDataProvider
-from Products.CMFPlone.utils import get_top_request
+from ..utils import get_top_request
 from Products.CMFPlone.utils import getFSVersionTuple
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import queryUtility

--- a/src/collective/collectionfilter/utils.py
+++ b/src/collective/collectionfilter/utils.py
@@ -68,3 +68,12 @@ def base_query(request_params={}, extra_ignores=[]):
     }
     urlquery.update({'collectionfilter': '1'})  # marker
     return urlquery
+
+def get_top_request(request):
+    """Get highest request from a subrequest.
+    """
+
+    def _top_request(req):
+        parent_request = req.get('PARENT_REQUEST', None)
+        return _top_request(parent_request) if parent_request else req
+    return _top_request(request)


### PR DESCRIPTION
This PR adds backward compatibility support for Plone 5.0.x

Closes #23 

## Notes

 - In 5.0.x pat-contentloader causes the portlets to disappear when loading content, so we have disabled this feature in 5.0.x.
 - In 5.0.x the 'basePath' pattern_option is 'not json serializable' and throws and exception, so we have disabled this pattern option.
 - We have removed some artefacts for Plone 4 which is not supported at all, so the code is a little cleaner.