### PR TITLE
Python 3 fix for @@render-portlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New features:
 
 Bug fixes:
 
+- fix bug in @@render-portlet for Python 3
+  [petschki]
+
 - Do not render an empty ``filterClassName``.
   [thet]
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'setuptools',
         'Products.CMFPlone >= 5.0',
         'plone.app.contenttypes',
+        'plone.app.portlets >= 4.4.2',
     ],
     entry_points="""
     # -*- Entry points: -*-

--- a/src/collective/collectionfilter/portlets/collectionfilter.py
+++ b/src/collective/collectionfilter/portlets/collectionfilter.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from collective.collectionfilter import _
 from collective.collectionfilter.baseviews import BaseFilterView
 from collective.collectionfilter.interfaces import ICollectionFilterSchema
 from collective.collectionfilter.vocabularies import DEFAULT_FILTER_TYPE
 from plone.app.portlets.portlets import base
 from plone.portlets.interfaces import IPortletDataProvider
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implementer
 
 try:
@@ -90,7 +91,7 @@ class Renderer(base.Renderer, BaseFilterView):
     def reload_url(self):
         reload_url = '{0}/@@render-portlet?portlethash={1}'.format(
             self.context.absolute_url(),
-            self.filter_id
+            safe_unicode(self.filter_id),
         )
         return reload_url
 

--- a/src/collective/collectionfilter/portlets/collectionsearch.py
+++ b/src/collective/collectionfilter/portlets/collectionsearch.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from collective.collectionfilter import _
 from collective.collectionfilter.baseviews import BaseSearchView
 from collective.collectionfilter.interfaces import ICollectionSearchSchema
 from plone.app.portlets.portlets import base
 from plone.portlets.interfaces import IPortletDataProvider
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implementer
 
 try:
@@ -62,7 +63,7 @@ class Renderer(base.Renderer, BaseSearchView):
     def reload_url(self):
         reload_url = '{0}/@@render-portlet?portlethash={1}'.format(
             self.context.absolute_url(),
-            self.filter_id
+            safe_unicode(self.filter_id),
         )
         return reload_url
 


### PR DESCRIPTION
NOTE for Python 3: this PR in `plone.app.portlets` fixes a mandatory py3 bug: https://github.com/plone/plone.app.portlets/pull/125 ... that's why I've added it to `install_requires` 