### PR TITLE
Performance improvement: only execute the catalog_search_fullcount query if its really needed for displaying the count

### DIFF
--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -97,6 +97,7 @@ class BaseFilterView(BaseView):
             group_by=self.settings.group_by,
             filter_type=self.settings.filter_type,
             narrow_down=self.settings.narrow_down,
+            show_count=self.settings.show_count,
             view_name=self.settings.view_name,
             cache_enabled=self.settings.cache_enabled,
             request_params=self.top_request.form or {}

--- a/src/collective/collectionfilter/filteritems.py
+++ b/src/collective/collectionfilter/filteritems.py
@@ -37,6 +37,7 @@ def _results_cachekey(
         group_by,
         filter_type=DEFAULT_FILTER_TYPE,
         narrow_down=False,
+        show_count=False,
         view_name='',
         cache_enabled=True,
         request_params=None):
@@ -47,6 +48,7 @@ def _results_cachekey(
         group_by,
         filter_type,
         narrow_down,
+        show_count,
         view_name,
         request_params,
         ' '.join(plone.api.user.get_roles()),
@@ -62,6 +64,7 @@ def get_filter_items(
         group_by,
         filter_type=DEFAULT_FILTER_TYPE,
         narrow_down=False,
+        show_count=False,
         view_name='',
         cache_enabled=True,
         request_params=None
@@ -110,7 +113,7 @@ def get_filter_items(
         brains=True,
         custom_query=custom_query
     )
-    if narrow_down:
+    if narrow_down and show_count:
         # we need the extra_ignores to get a true count
         # even when narrow_down filters the display of indexed values
         # count_query allows us to do that true count
@@ -208,7 +211,7 @@ def get_filter_items(
     urlquery_all = {
         k: v for k, v in list(urlquery.items()) if k not in (idx, idx + '_op')
     }
-    if narrow_down:
+    if narrow_down and show_count:
         catalog_results = catalog_results_fullcount
     ret = [{
         'title': translate(

--- a/src/collective/collectionfilter/tests/test_filteritems.py
+++ b/src/collective/collectionfilter/tests/test_filteritems.py
@@ -57,6 +57,7 @@ class TestFilteritems(unittest.TestCase):
             self.collection_uid, 'Subject',
             request_params={'Subject': u'Dokumänt'},
             narrow_down=True,
+            show_count=True,
             cache_enabled=False)
 
         self.assertEqual(
@@ -94,6 +95,7 @@ class TestFilteritems(unittest.TestCase):
             self.collection_uid, 'portal_type',
             request_params={'portal_type': u'Event'},
             narrow_down=True,
+            show_count=True,
             cache_enabled=False)
 
         self.assertEqual(len(result), 2)


### PR DESCRIPTION
The show count fix is only needed when the count is actually displayed. In all other cases, the extra cataloig query ``catalog_search_fullcount`` is unnecessary. 
See: #52 