### PR TITLE
Create separate layers for testing functionality with AJAX enabled and AJAX disabled

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ omit =
     bin/test
     eggs/*
     parts/*
+    src/collective/collectionfilter/testing.py
     src/collective/collectionfilter/tests/*
     */lib/*
     *.txt

--- a/src/collective/collectionfilter/testing.py
+++ b/src/collective/collectionfilter/testing.py
@@ -10,6 +10,14 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import applyProfile
 from plone.app.textfield.value import RichTextValue
 from plone.testing import z2
+import json
+
+
+def _set_ajax_enabled(should_enable_ajax):
+    pattern_options = api.portal.get_registry_record("plone.patternoptions")
+    data = {"collectionfilter": unicode(json.dumps({"ajaxLoad": should_enable_ajax}))}
+    pattern_options.update(data)
+    api.portal.set_registry_record("plone.patternoptions", pattern_options)
 
 
 class CollectiveCollectionFilterLayer(PloneSandboxLayer):
@@ -82,17 +90,34 @@ COLLECTIVE_COLLECTIONFILTER_INTEGRATION_TESTING = IntegrationTesting(
 )
 
 
-COLLECTIVE_COLLECTIONFILTER_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(COLLECTIVE_COLLECTIONFILTER_FIXTURE,),
-    name='CollectiveCollectionFilterLayer:FunctionalTesting',
-)
+class CollectiveCollectionFilterAjaxEnabledLayer(CollectiveCollectionFilterLayer):
+    def setUpPloneSite(self, portal):
+        _set_ajax_enabled(True)
+        super(CollectiveCollectionFilterAjaxEnabledLayer, self).setUpPloneSite(portal)
 
-
-COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING = FunctionalTesting(
+AJAX_ENABLED_FIXTURE = CollectiveCollectionFilterAjaxEnabledLayer()
+COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_ENABLED = FunctionalTesting(
     bases=(
-        COLLECTIVE_COLLECTIONFILTER_FIXTURE,
+        AJAX_ENABLED_FIXTURE,
         REMOTE_LIBRARY_BUNDLE_FIXTURE,
         z2.ZSERVER_FIXTURE,
     ),
-    name='CollectiveCollectionFilterLayer:AcceptanceTesting',
+    name='CollectiveCollectionFilterLayer:AcceptanceTesting_AjaxEnabled',
+)
+
+
+class CollectiveCollectionFilterAjaxDisabledLayer(CollectiveCollectionFilterLayer):
+    def setUpPloneSite(self, portal):
+        _set_ajax_enabled(False)
+        super(CollectiveCollectionFilterAjaxDisabledLayer, self).setUpPloneSite(portal)
+
+
+AJAX_DISABLED_FIXTURE = CollectiveCollectionFilterAjaxDisabledLayer()
+COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_DISABLED = FunctionalTesting(
+    bases=(
+        AJAX_DISABLED_FIXTURE,
+        REMOTE_LIBRARY_BUNDLE_FIXTURE,
+        z2.ZSERVER_FIXTURE,
+    ),
+    name='CollectiveCollectionFilterLayer:AcceptanceTesting_AjaxDisabled',
 )

--- a/src/collective/collectionfilter/testing.py
+++ b/src/collective/collectionfilter/testing.py
@@ -95,6 +95,15 @@ COLLECTIVE_COLLECTIONFILTER_INTEGRATION_TESTING = IntegrationTesting(
     name='CollectiveCollectionFilterLayer:IntegrationTesting',
 )
 
+COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING = FunctionalTesting(
+    bases=(
+        COLLECTIVE_COLLECTIONFILTER_FIXTURE,
+        REMOTE_LIBRARY_BUNDLE_FIXTURE,
+        z2.ZSERVER_FIXTURE,
+    ),
+    name='CollectiveCollectionFilterLayer:AcceptanceTesting',
+)
+
 
 class CollectiveCollectionFilterAjaxEnabledLayer(CollectiveCollectionFilterLayer):
     def setUpPloneSite(self, portal):

--- a/src/collective/collectionfilter/testing.py
+++ b/src/collective/collectionfilter/testing.py
@@ -12,6 +12,12 @@ from plone.app.textfield.value import RichTextValue
 from plone.testing import z2
 import json
 
+try:
+    # Python 2: "unicode" is built-in
+    unicode
+except NameError:
+    unicode = str
+
 
 def _set_ajax_enabled(should_enable_ajax):
     pattern_options = api.portal.get_registry_record("plone.patternoptions")

--- a/src/collective/collectionfilter/tests/robot/keywords.robot
+++ b/src/collective/collectionfilter/tests/robot/keywords.robot
@@ -93,6 +93,43 @@ Set Batch Size
     Click element  css=input#form-buttons-save
     Go to  ${PLONE_URL}/testcollection
 
+Ajax has completed
+    Wait For Condition	return jQuery.active == 0  timeout=5 sec
+
+# --- Setup -------------------------------------------------------------------
+I've got a site with a collection
+    Log in as site owner
+    Go to  ${PLONE_URL}/testcollection
+
+My collection has a collection search portlet
+    Go to  ${PLONE_URL}/testcollection
+    Click element  link=Manage portlets
+    Element should be visible  css=#plone-contentmenu-portletmanager > ul
+    Click element  partial link=Right
+    Add search portlet
+
+My collection has a collection filter portlet
+    Go to  ${PLONE_URL}/testcollection
+    Click element  link=Manage portlets
+    Element should be visible  css=#plone-contentmenu-portletmanager > ul
+    Click element  partial link=Right
+    Add filter portlet  Subject  or  checkboxes_dropdowns
+
+I'm viewing the collection
+    Go to  ${PLONE_URL}/testcollection
+    Should be 3 collection results
+
+
+# --- Core Functionality ------------------------------------------------------
+I search for ${document} with ajax
+    Wait until element is not visible  css=.collectionSearch button[type='submit']  timeout=5 sec
+    Input text  css=.collectionSearch input[name='SearchableText']  ${document}
+    Wait until keyword succeeds  5s  1s  Ajax has completed
+
+I search for ${document} and click search
+    Wait until element is visible  css=.collectionSearch button[type='submit']
+    Input text  css=.collectionSearch input[name='SearchableText']  ${document}
+    Click Element  css=.collectionSearch button[type='submit']
 
 # --- Tiles -------------------------------------------------------------------
 Enable mosaic layout for page
@@ -173,8 +210,3 @@ Filter by
     [Arguments]  ${filter}
     Wait until element is visible  css=.filterContent
     Select from List by value  xpath=//div[@class = 'filterContent']//select  ${filter}
-
-Search for
-    [Arguments]  ${document}
-    Input text  css=.collectionSearch input[name='SearchableText']  ${document}
-    Click Element  css=.collectionSearch button[type='submit']

--- a/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
+++ b/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
@@ -3,7 +3,7 @@
 
 Resource  keywords.robot
 
-Library  Remote  ${PLONE_URL}/RobotRemote
+# Library  Remote  ${PLONE_URL}/RobotRemote
 
 Test Setup  Open test browser
 Test Teardown  Close all browsers
@@ -32,18 +32,6 @@ Scenario: Add filter portlets to collection
     Capture Page Screenshot
     Click element  css=li.filter-all.checkbox input
     Should be 3 collection results
-
-    Input text  css=.collectionSearch input[name='SearchableText']  Document
-    # Text input is reloaded live ... wait a bit
-    Should be 1 collection results
-
-    # check for filtered subject checkbox list
-    Should be 3 filter checkboxes
-
-    # the following doesn't work ... I think no 'keyup' event is fired
-    #Input text  css=.collectionSearch input[name='SearchableText']
-    #Should be 2 collection results
-    #Should be 4 filter checkboxes
 
 
 Scenario: Test Batching

--- a/src/collective/collectionfilter/tests/robot/test_filterportlets_ajaxdisabled.robot
+++ b/src/collective/collectionfilter/tests/robot/test_filterportlets_ajaxdisabled.robot
@@ -1,0 +1,27 @@
+
+*** Settings *****************************************************************
+
+Resource  keywords.robot
+
+# Library  Remote  ${PLONE_URL}/RobotRemote
+
+Test Setup  Open test browser
+Test Teardown  Close all browsers
+
+
+*** Test Cases ***************************************************************
+
+Scenario: Searching through a portlet with ajax disabled
+    Given I've got a site with a collection
+      and my collection has a collection search portlet
+      and my collection has a collection filter portlet
+      and I'm viewing the collection
+    When I search for Document and click search
+    Then should be 1 collection results
+      and should be 3 filter checkboxes   
+
+    # the following doesn't work ... I think no 'keyup' event is fired
+    # Given I'm viewing the collection
+    # When I search for ${EMPTY} and click search
+    # Then should be 2 collection results
+    #   and should be 4 filter checkboxes   

--- a/src/collective/collectionfilter/tests/robot/test_filterportlets_ajaxenabled.robot
+++ b/src/collective/collectionfilter/tests/robot/test_filterportlets_ajaxenabled.robot
@@ -1,0 +1,27 @@
+
+*** Settings *****************************************************************
+
+Resource  keywords.robot
+
+# Library  Remote  ${PLONE_URL}/RobotRemote
+
+Test Setup  Open test browser
+Test Teardown  Close all browsers
+
+
+*** Test Cases ***************************************************************
+
+Scenario: Searching through a portlet with ajax enabled
+    Given I've got a site with a collection
+      and my collection has a collection search portlet
+      and my collection has a collection filter portlet
+      and I'm viewing the collection
+    When I search for Document with ajax
+    Then should be 1 collection results
+      and should be 3 filter checkboxes   
+
+    # the following doesn't work ... I think no 'keyup' event is fired
+    # Given I'm viewing the collection
+    # When I search for ${EMPTY} with ajax
+    # Then should be 2 collection results
+    #   and should be 4 filter checkboxes   

--- a/src/collective/collectionfilter/tests/robot/test_filtertiles_ajaxdisabled.robot
+++ b/src/collective/collectionfilter/tests/robot/test_filtertiles_ajaxdisabled.robot
@@ -3,7 +3,7 @@
 
 Resource  keywords.robot
 
-Library  Remote  ${PLONE_URL}/RobotRemote
+# Library  Remote  ${PLONE_URL}/RobotRemote
 
 Test Setup  Open test browser
 Test Teardown  Close all browsers
@@ -34,17 +34,18 @@ Scenario: Add filter tiles to page for collection
     Capture Page screenshot
 
     # Check collection filter filters collections
+    # Broken when running with AJAX enabled
     Go to  ${TEST_PAGE}
     Filter by  Dokumänt
     Should be 2 collection results
     Capture Page Screenshot
-    # Filtering by all with checkboxes_dropdowns without ajax results in no page change
-
+    
     # Check collection search filters collections
-    Go to  ${TEST_PAGE}
-    Search for  Document
-    Should be 1 collection results
-    Capture Page Screenshot
-    Go to  ${TEST_PAGE}
-    Search for  ${EMPTY}
-    Should be 3 collection results
+    Given go to  ${TEST_PAGE}
+    When I search for Document and click search
+    Then should be 1 collection results
+      and Capture Page Screenshot
+
+    Given Go to  ${TEST_PAGE}
+    When I search for ${EMPTY} and click search
+    Then should be 3 collection results

--- a/src/collective/collectionfilter/tests/test_robot.py
+++ b/src/collective/collectionfilter/tests/test_robot.py
@@ -22,14 +22,18 @@ def test_suite():
         if doc.endswith('.robot') and doc.startswith('test_')
     ]
     for robot_test in robot_tests:
-        if "ajaxenabled" in robot_test and api.env.plone_version() > '5.0':
-            test_layer = (
-                COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_ENABLED
-            )
+        if "ajaxenabled" in robot_test:
+            if api.env.plone_version() < '5.1':
+                break
+            else:
+                test_layer = (
+                    COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_ENABLED
+                )
         elif "ajaxdisabled" in robot_test:
             test_layer = (
                 COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_DISABLED
             )
+
         else:
             test_layer = COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING
 

--- a/src/collective/collectionfilter/tests/test_robot.py
+++ b/src/collective/collectionfilter/tests/test_robot.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from collective.collectionfilter.testing import COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING  # noqa
+from collective.collectionfilter.testing import (
+    COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_ENABLED,
+    COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_DISABLED,
+)  # noqa
 from plone.app.testing import ROBOT_TEST_LEVEL
 from plone.testing import layered
 
@@ -17,12 +20,25 @@ def test_suite():
         if doc.endswith('.robot') and doc.startswith('test_')
     ]
     for robot_test in robot_tests:
-        robottestsuite = robotsuite.RobotTestSuite(robot_test)
-        robottestsuite.level = ROBOT_TEST_LEVEL
-        suite.addTests([
-            layered(
-                robottestsuite,
-                layer=COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING,
-            ),
-        ])
+        robottestsuite_ajax_enabled = robotsuite.RobotTestSuite(robot_test)
+        robottestsuite_ajax_enabled.level = ROBOT_TEST_LEVEL
+        suite.addTests(
+            [
+                layered(
+                    robottestsuite_ajax_enabled,
+                    layer=COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_ENABLED,
+                )
+            ]
+        )
+        robottestsuite_ajax_disabled = robotsuite.RobotTestSuite(robot_test)
+        robottestsuite_ajax_disabled.level = ROBOT_TEST_LEVEL
+        suite.addTests(
+            [
+                layered(
+                    robottestsuite_ajax_disabled,
+                    layer=COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_DISABLED,
+                )
+            ]
+        )
+
     return suite


### PR DESCRIPTION
The differences in UI and functionality when AJAX was disabled was causing tests to fail. This PR adds separate layers for running the robot tests with ajax enabled and disabled to fix the failing tests.
Closes #81 