### PR TITLE
Use plone.memoize to cache groupby criteria

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Changelog
 - Added css_modifier to extend css class of a filter item
   [agitator]
 
+Bug fixes:
+
+ - Use plone.memoize to cache groupby criteria
+   [instification]
+
 
 3.2.1 (2019-08-07)
 ------------------


### PR DESCRIPTION
Fixes #87

I have used the path to the site and the time of the last transaction (if any) on portal_catalog as the cache key. This ensures that any changes to the index that could affect the groupby results are reflected in the list.

ie. if I add a new index to the catalog, it should be immediately available in the groupby criteria.