### PR TITLE
Fix check for boolean values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Added css_modifier to extend css class of a filter item
   [agitator]
+- Fix check for boolean values.
+  [tmassman]
 
 
 3.2.1 (2019-08-07)

--- a/src/collective/collectionfilter/filteritems.py
+++ b/src/collective/collectionfilter/filteritems.py
@@ -8,6 +8,7 @@ from collective.collectionfilter.utils import safe_encode
 from collective.collectionfilter.utils import safe_iterable
 from collective.collectionfilter.vocabularies import DEFAULT_FILTER_TYPE
 from collective.collectionfilter.vocabularies import EMPTY_MARKER
+from Missing import Missing
 from plone.app.contenttypes.behaviors.collection import ICollection
 from plone.app.event.base import _prepare_range
 from plone.app.event.base import guess_date_from
@@ -155,7 +156,7 @@ def get_filter_items(
         val = safe_iterable(val)
 
         for filter_value in val:
-            if not filter_value:
+            if filter_value is None or isinstance(filter_value, Missing):
                 continue
             if value_blacklist and filter_value in value_blacklist:
                 # Do not include blacklisted

--- a/src/collective/collectionfilter/testing.py
+++ b/src/collective/collectionfilter/testing.py
@@ -66,6 +66,7 @@ class CollectiveCollectionFilterLayer(PloneSandboxLayer):
                 start=datetime.now() + timedelta(days=1),
                 end=datetime.now() + timedelta(days=2),
                 subject=[u'Süper', u'Evänt'],
+                exclude_from_nav=False,
             )
             portal.invokeFactory(
                 'Document',
@@ -73,6 +74,7 @@ class CollectiveCollectionFilterLayer(PloneSandboxLayer):
                 title=u'Test Document 😉',
                 text=RichTextValue(u'Ein heißes Test Dokument'),
                 subject=[u'Süper', u'Dokumänt'],
+                exclude_from_nav=False,
             )
             portal.invokeFactory(
                 'Document',
@@ -80,6 +82,7 @@ class CollectiveCollectionFilterLayer(PloneSandboxLayer):
                 title=u'Page 😉',
                 text=RichTextValue(u'Ein heißes Test Dokument'),
                 subject=[u'Dokumänt'],
+                exclude_from_nav=True,
             )
             doc = portal['testdoc']
             # doc.geolocation.latitude = 47.4048832

--- a/src/collective/collectionfilter/testing.py
+++ b/src/collective/collectionfilter/testing.py
@@ -10,6 +10,7 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import applyProfile
 from plone.app.textfield.value import RichTextValue
 from plone.testing import z2
+from Products.PluginIndexes.BooleanIndex.BooleanIndex import BooleanIndex
 import json
 
 try:
@@ -47,6 +48,13 @@ class CollectiveCollectionFilterLayer(PloneSandboxLayer):
         applyProfile(portal, 'collective.geolocationbehavior:default')
         applyProfile(portal, 'collective.collectionfilter:default')
         applyProfile(portal, 'collective.collectionfilter.tests:testing')
+
+        catalog = api.portal.get_tool(name='portal_catalog')
+        if 'exclude_from_nav' not in catalog.indexes():
+            catalog.addIndex(
+                'exclude_from_nav',
+                BooleanIndex('exclude_from_nav'),
+            )
 
         with api.env.adopt_roles(['Manager']):
             portal.invokeFactory(

--- a/src/collective/collectionfilter/tests/test_filteritems.py
+++ b/src/collective/collectionfilter/tests/test_filteritems.py
@@ -205,3 +205,52 @@ class TestFilteritems(unittest.TestCase):
             custom_query=make_query(qs(result, u'Evänt'))
         )
         self.assertEqual(len(catalog_results), 0)
+
+    def test_boolean_filter(self):
+        """Validate boolean fields are shown with all values."""
+        self.assertEqual(len(self.collection.results()), 3)
+
+        result = get_filter_items(
+            self.collection_uid, 'exclude_from_nav', cache_enabled=False)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(get_data_by_val(result, 'all')['count'], 3)
+        self.assertEqual(get_data_by_val(result, 'all')['selected'], True)
+        self.assertEqual(get_data_by_val(result, True)['count'], 1)
+        self.assertEqual(get_data_by_val(result, False)['count'], 2)
+
+        # test narrowed down results
+        narrowed_down_result = get_filter_items(
+            self.collection_uid, 'exclude_from_nav',
+            request_params={'exclude_from_nav': True},
+            narrow_down=True,
+            show_count=True,
+            cache_enabled=False)
+
+        self.assertEqual(
+            len(narrowed_down_result), 2,
+            msg=u"narrowed result length should be 2")
+        self.assertEqual(
+            get_data_by_val(narrowed_down_result, True)['selected'], True,  # noqa
+            msg=u"Test that 'Yes' is selected, matching the query")
+        self.assertEqual(
+            get_data_by_val(narrowed_down_result, u'all')['count'], 3,
+            msg=u"Test that there are 3 results if unselected")
+
+        # test narrowed down results
+        narrowed_down_result = get_filter_items(
+            self.collection_uid, 'exclude_from_nav',
+            request_params={'exclude_from_nav': False},
+            narrow_down=True,
+            show_count=True,
+            cache_enabled=False)
+
+        self.assertEqual(
+            len(narrowed_down_result), 2,
+            msg=u"narrowed result length should be 2")
+        self.assertEqual(
+            get_data_by_val(narrowed_down_result, False)['selected'], True,  # noqa
+            msg=u"Test that 'No' is selected, matching the query")
+        self.assertEqual(
+            get_data_by_val(narrowed_down_result, u'all')['count'], 3,
+            msg=u"Test that there are 3 results if unselected")

--- a/src/collective/collectionfilter/utils.py
+++ b/src/collective/collectionfilter/utils.py
@@ -41,7 +41,7 @@ def safe_decode(val):
     """
     ret = val
     if isinstance(val, dict):
-        ret = dict([(safe_decode(k), safe_decode(v)) for k, v in val.items() if v])  # noqa
+        ret = dict([(safe_decode(k), safe_decode(v)) for k, v in val.items() if v is not None])  # noqa
     elif isinstance(val, list):
         ret = [safe_decode(it) for it in val]
     elif isinstance(val, tuple):
@@ -56,7 +56,7 @@ def safe_encode(val):
     """
     ret = val
     if isinstance(val, dict):
-        ret = dict([(safe_encode(k), safe_encode(v)) for k, v in val.items() if v])  # noqa
+        ret = dict([(safe_encode(k), safe_encode(v)) for k, v in val.items() if v is not None])  # noqa
     elif isinstance(val, list):
         ret = [safe_encode(it) for it in val]
     elif isinstance(val, tuple):

--- a/src/collective/collectionfilter/vocabularies.py
+++ b/src/collective/collectionfilter/vocabularies.py
@@ -53,6 +53,26 @@ DEFAULT_FILTER_TYPE = 'single'
 LIST_SCALING = ['No Scaling', 'Linear', 'Logarithmic']
 
 
+def make_bool(value):
+    """Transform into a boolean value."""
+    truthy = [
+        safe_encode('true'),
+        safe_encode('1'),
+        safe_encode('t'),
+        safe_encode('yes'),
+    ]
+    if value is None:
+        return
+    if isinstance(value, bool):
+        return value
+    value = safe_encode(value)
+    value = value.lower()
+    if value in truthy:
+        return True
+    else:
+        return False
+
+
 @implementer(IGroupByCriteria)
 class GroupByCriteria():
     """Global utility for retrieving and manipulating groupby criterias.
@@ -86,6 +106,9 @@ class GroupByCriteria():
             if six.PY2 and getattr(idx, 'meta_type', None) == 'KeywordIndex':
                 # in Py2 KeywordIndex accepts only utf-8 encoded values.
                 index_modifier = safe_encode
+
+            if getattr(idx, 'meta_type', None) == 'BooleanIndex':
+                index_modifier = make_bool
 
             self._groupby[it] = {
                 'index': it,


### PR DESCRIPTION
`False` values never showed up for boolean indices. Also, the url generation for boolean indices was wrong (figured that out while writing the tests).

I also added a custom `display_modifier` and `index_modifier` for boolean indices, to show a better human readable result (**yes** and **no** instead of **true** and **false**). I saw when writing the tests that I did that for all boolean indices in a customer project and decided it would be a good extension, also way beyond the intentional fix. If you don't like this, please remove it 😉 