### PR TITLE
Fix failing tests by using Travis google chrome addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: python
 sudo: false
 addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 matrix:
   include:
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ before_install:
   - cp test-$PLONE_VERSION.cfg buildout.cfg
   - pip2.7 install popt || pip2.7 install --user  popt
 install:
-  - buildout -N annotate
-  - buildout -N
+  # - buildout -N annotate
+  - buildout -N -vvvvv
   - pip install zest.pocompile
   - pocompile src
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - pip2.7 install popt || pip2.7 install --user  popt
 install:
   # - buildout -N annotate
-  - buildout -N -vvvvv
+  - buildout -N
   - pip install zest.pocompile
   - pocompile src
 before_script:

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -199,6 +199,7 @@ class BaseSearchView(BaseView):
         ] if it])
         return ajax_url
 
+
 if HAS_GEOLOCATION:
 
     class BaseMapsView(BaseView):

--- a/src/collective/collectionfilter/testing.py
+++ b/src/collective/collectionfilter/testing.py
@@ -121,6 +121,7 @@ class CollectiveCollectionFilterAjaxEnabledLayer(CollectiveCollectionFilterLayer
         _set_ajax_enabled(True)
         super(CollectiveCollectionFilterAjaxEnabledLayer, self).setUpPloneSite(portal)
 
+
 AJAX_ENABLED_FIXTURE = CollectiveCollectionFilterAjaxEnabledLayer()
 COLLECTIVE_COLLECTIONFILTER_ACCEPTANCE_TESTING_AJAX_ENABLED = FunctionalTesting(
     bases=(

--- a/src/collective/collectionfilter/tests/test_filteritems.py
+++ b/src/collective/collectionfilter/tests/test_filteritems.py
@@ -3,7 +3,7 @@
 import unittest
 try:
     from urllib.parse import urlparse, parse_qs
-except:
+except ImportError:
     from urlparse import urlparse, parse_qs
 
 from plone.app.contenttypes.interfaces import ICollection

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -38,3 +38,7 @@ robotframework = 3.0.4
 robotframework-seleniumlibrary = 3.2.0
 robotsuite = 2.0.0
 selenium = >=3.4.0
+
+# Version conflicts caused by code analysis
+flake8 = 3.5.0
+pyflakes = 1.5.0

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -40,5 +40,6 @@ robotsuite = 2.0.0
 selenium = >=3.4.0
 
 # Version conflicts caused by code analysis
+pycodestyle = 2.3.1
 flake8 = 3.5.0
 pyflakes = 1.5.0

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -41,5 +41,6 @@ selenium = >=3.4.0
 
 # Version conflicts caused by code analysis
 pycodestyle = 2.3.1
+configparser = 5.0.0
 flake8 = 3.5.0
 pyflakes = 1.5.0


### PR DESCRIPTION
[this PR](https://github.com/travis-ci/apt-source-safelist/pull/416) for Travis seems to suggest that the current method of using the apt plugin to install Google Chrome is deprecated. There is now an official [chrome addon for travis](https://docs.travis-ci.com/user/chrome#selecting-a-chrome-version), which seems to build okay