### PR TITLE
WIP: Disable _all_ filter option

### DIFF
--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -154,6 +154,7 @@ class BaseFilterView(BaseView):
             cache_enabled=self.settings.cache_enabled,
             request_params=self.top_request.form or {},
             content_selector=self.settings.content_selector,
+            include_all_option=self.settings.enable_all_filter_option
         )
         return results
 

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -154,7 +154,7 @@ class BaseFilterView(BaseView):
             cache_enabled=self.settings.cache_enabled,
             request_params=self.top_request.form or {},
             content_selector=self.settings.content_selector,
-            include_all_option=self.settings.enable_all_filter_option
+            include_all_option=self.settings.enable_all_filter_option,
         )
         return results
 

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -156,6 +156,24 @@ class BaseFilterView(BaseView):
             content_selector=self.settings.content_selector,
             include_all_option=self.settings.enable_all_filter_option,
         )
+        if not getattr(self.request, "collectionfilter", None):
+            existing_query_string = self.request["QUERY_STRING"]
+            default_filter_query_string = "%s=%s" % (
+                self.settings.group_by,
+                results[0]["value"],
+            )
+            if existing_query_string:
+                default_filter_query_string = "&" + default_filter_query_string
+
+            query_string = (
+                existing_query_string
+                if self.settings.enable_all_filter_option
+                else existing_query_string + default_filter_query_string
+            )
+            self.request.response.redirect(
+                "%s?collectionfilter=1%s"
+                % (self.request["ACTUAL_URL"], query_string)
+            )
         return results
 
     @property

--- a/src/collective/collectionfilter/filteritems.py
+++ b/src/collective/collectionfilter/filteritems.py
@@ -78,6 +78,7 @@ def get_filter_items(
     cache_enabled=True,
     request_params=None,
     content_selector="",
+    include_all_option=True,
 ):
     request_params = request_params or {}
     custom_query = {}  # Additional query to filter the collection
@@ -229,7 +230,7 @@ def get_filter_items(
             "count": len(catalog_results),
             "selected": idx not in request_params,
         }
-    ]
+    ] if include_all_option else []
 
     grouped_results = list(grouped_results.values())
 

--- a/src/collective/collectionfilter/filteritems.py
+++ b/src/collective/collectionfilter/filteritems.py
@@ -48,6 +48,7 @@ def _results_cachekey(
     cache_enabled=True,
     request_params=None,
     content_selector="",
+    include_all_option=True,
 ):
     if not cache_enabled:
         raise DontCache
@@ -60,6 +61,7 @@ def _results_cachekey(
         view_name,
         request_params,
         content_selector,
+        include_all_option,
         " ".join(plone.api.user.get_roles()),
         plone.api.portal.get_current_language(),
         str(plone.api.portal.get_tool("portal_catalog").getCounter()),

--- a/src/collective/collectionfilter/interfaces.py
+++ b/src/collective/collectionfilter/interfaces.py
@@ -160,7 +160,7 @@ class ICollectionFilterSchema(ICollectionFilterBaseSchema):
     )
 
     enable_all_filter_option = schema.Bool(
-        title=_(u"label_enable_all_filter_option", default=u"Enable 'all' filter"),  # noqa
+        title=_(u"label_enable_all_filter_option", default=u"Enable all filter option"),  # noqa
         description=_(
             u"help_enable_all_filter_option",
             default=u"Enabling this will show an 'all' option in the collection filter.",

--- a/src/collective/collectionfilter/interfaces.py
+++ b/src/collective/collectionfilter/interfaces.py
@@ -159,6 +159,16 @@ class ICollectionFilterSchema(ICollectionFilterBaseSchema):
         required=False,
     )
 
+    enable_all_filter_option = schema.Bool(
+        title=_(u"label_enable_all_filter_option", default=u"Enable 'all' filter"),  # noqa
+        description=_(
+            u"help_enable_all_filter_option",
+            default=u"Enabling this will show an 'all' option in the collection filter.",
+        ),
+        default=True,
+        required=False,
+    )
+
 
 #    list_scaling = schema.Choice(
 #        title=_('label_list_scaling', u'List scaling'),

--- a/src/collective/collectionfilter/portlets/collectionfilter.py
+++ b/src/collective/collectionfilter/portlets/collectionfilter.py
@@ -27,8 +27,8 @@ class Assignment(base.Assignment):
     narrow_down = False
     view_name = None
     content_selector = "#content-core"
-    hide_if_empty = False,
-    enable_all_filter_option = True,
+    hide_if_empty = False
+    enable_all_filter_option = True
     # list_scaling = None
 
     def __init__(

--- a/src/collective/collectionfilter/portlets/collectionfilter.py
+++ b/src/collective/collectionfilter/portlets/collectionfilter.py
@@ -27,7 +27,8 @@ class Assignment(base.Assignment):
     narrow_down = False
     view_name = None
     content_selector = "#content-core"
-    hide_if_empty = False
+    hide_if_empty = False,
+    enable_all_filter_option = True,
     # list_scaling = None
 
     def __init__(
@@ -43,6 +44,7 @@ class Assignment(base.Assignment):
         view_name=None,
         content_selector="#content-core",
         hide_if_empty=False,
+        enable_all_filter_option=True,
         # list_scaling=None
     ):
         self.header = header
@@ -56,6 +58,7 @@ class Assignment(base.Assignment):
         self.view_name = view_name
         self.content_selector = content_selector
         self.hide_if_empty = hide_if_empty
+        self.enable_all_filter_option = enable_all_filter_option
         # self.list_scaling = list_scaling
 
     @property

--- a/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
+++ b/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
@@ -50,6 +50,14 @@ Scenario: Hide when no options
      then Should be 3 collection results
      then Should be 0 filter options
 
+Scenario: Disable all filter option
+
+    Given I've got a site with a collection
+      and my collection has a collection filter  author_name  or  checkboxes_dropdowns  Enable all filter option
+     When I'm viewing the collection
+     then Should be 3 collection results
+     then Should be 0 filter options
+
 
 Scenario: show hidden filter if just narrowed down
 

--- a/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
+++ b/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
@@ -53,10 +53,10 @@ Scenario: Hide when no options
 Scenario: Disable all filter option
 
     Given I've got a site with a collection
-      and my collection has a collection filter  author_name  or  checkboxes_dropdowns  Enable all filter option
+      and my collection has a collection filter  Subject  or  checkboxes_dropdowns  Enable all filter option
      When I'm viewing the collection
      then Should be 3 collection results
-     then Should be 0 filter options
+      and Should be filter checkboxes  All (3)  Dokumänt (2)  Evänt (1)  Süper (2)
 
 
 Scenario: show hidden filter if just narrowed down


### PR DESCRIPTION
This PR adds an option to the collection filter settings panel to disable the 'All' option from the filter list. In order to provide a default filtering fallback, this PR also adds a redirect to the current page with `collectionfilter=1` added as a query string if the collectionfilter is about to be displayed but the query string is missing. This is because the [filtering of the collection is done by an event handler for each page traversal on the site](https://github.com/collective/collective.collectionfilter/blob/5c1350d99c0983e11e5316527be7ebfe92142ccd/src/collective/collectionfilter/contentfilter.py#L5-L14).