### PR TITLE
Fix non-alphanumeric only searches throwing an exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Bug Fixes:
 
 - Ensure a `GroupByCriteria`'s `sort_key_function` function `lower()` call gets a string.
   [jensens]
+- Fixed searches for only non-alphanumeric characters causing an exception to be displayed.
+  [JeffersonBledsoe]
 
 Other:
 

--- a/src/collective/collectionfilter/query.py
+++ b/src/collective/collectionfilter/query.py
@@ -10,6 +10,8 @@ from Products.CMFPlone.browser.search import BAD_CHARS
 from Products.CMFPlone.browser.search import quote_chars
 from zope.component import getUtility
 
+from Products.CMFPlone.UnicodeSplitter.config import rxGlob_U
+
 
 try:
     from Products.CMFPlone.browser.search import quote
@@ -28,6 +30,8 @@ ENCODED_BAD_CHARS = safe_decode(BAD_CHARS)
 
 
 def sanitise_search_query(query):
+    if not rxGlob_U.findall(query):
+        return u""
     for char in ENCODED_BAD_CHARS:
         query = query.replace(char, " ")
     clean_query = [quote(token) for token in query.split()]

--- a/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
+++ b/src/collective/collectionfilter/tests/robot/test_filterportlets.robot
@@ -106,6 +106,11 @@ Scenario: Search filter
     Then should be 1 collection results
       and Should be filter checkboxes  All (1)  Dokumänt (1)  Süper (1)
 
+    When I search for "& - * $"
+    # Checking for no error rather than results as Plone 5.2 will display no
+    #   results for a 'bad' query, while Plone 5.1/ 5.0 will display all of the results
+    Then page should not contain  error
+
     # Searching for query keywords (https://github.com/collective/collective.collectionfilter/issues/85)
     When I search for "and Document"
     Then should be 1 collection results


### PR DESCRIPTION
This PR fixes an exception that is thrown when you search for just non-alphanumeric characters (e.g. `&`). The reason for the exception is detailed in the comments in #86. The exception is prevented by removing the 'bad' characters from the `contentFilter` that is passed to the collection. The input and the URL querystring for the search will still retain the characters to maintain consistency.

Closes #86