### PR TITLE
Fix 5.2 test build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches-ignore:
-      - "master"
       - "releases/**"
 
 jobs:

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -18,7 +18,5 @@ test-eggs =
 extensions +=
     flake8-black
 
-[versions]
-#setuptools =
-#zc.buildout =
+[versions:python3]
 coverage = >=3.7


### PR DESCRIPTION
The coverage package was pulling python 3-only code for python 2. This PR adjusts the version pinning to resolve this.