### PR TITLE
Select default `ICollectionish` content

### DIFF
--- a/news/201.feature
+++ b/news/201.feature
@@ -1,0 +1,4 @@
+Implement CSS class for disabling `collectionfilter:reload` event when
+links in enhanced custom filter templates  are designed for other actions
+(eg. dropdowns or collapsibles).
+[petschki]

--- a/news/202.bugfix
+++ b/news/202.bugfix
@@ -1,0 +1,2 @@
+Fix selecting default `content_selector` for mosaic pages with contentlisting tile.
+[petschki]

--- a/src/collective/collectionfilter/baseviews.py
+++ b/src/collective/collectionfilter/baseviews.py
@@ -108,6 +108,9 @@ class BaseView:
         collectionish = (
             ICollectionish(self.collection.getObject()) if self.collection else None
         )
+        if collectionish is not None:
+            # select default content
+            collectionish.selectContent()
         selector = collectionish.content_selector
         if collectionish is None or not selector:
             return "#content-core"

--- a/src/collective/collectionfilter/tests/robot/keywords.robot
+++ b/src/collective/collectionfilter/tests/robot/keywords.robot
@@ -248,7 +248,7 @@ Should be ${X} collection results
     # below should work for both collections and contentlisting tiles
     ${xpath}=  Set Variable if  ${USE_TILES}  //span[@class='summary']  //div[@class='entries']/article
     Run keyword if  ${X}>0  Wait For Elements  xpath=${xpath}
-    Sleep  0.2
+    Sleep  0.5
     ${count} =  Get Element Count  xpath=${xpath}
     Should Be Equal as Numbers  ${count}  ${X}
 


### PR DESCRIPTION
Fix bug introduced in #150 where no default content was selected on mosaic pages with "contentlisting" tile